### PR TITLE
トップページのお知らせ欄用ボタン対応（if文追記）

### DIFF
--- a/src/ejs/parts/component/_c-btn.ejs
+++ b/src/ejs/parts/component/_c-btn.ejs
@@ -4,4 +4,7 @@
 <%# whiteの場合は背景が白、文字色が黒 %>
 <% } else if(backcolor == 'white') { %>
   <a href="<%= link %>" class="c-btn--white"><%= text %></a>
+<%# halfの場合はSP版は背景が黒、PC版は背景が白 %>
+<% } else if(backcolor == 'half') { %>
+  <a href="<%= link %>" class="c-btn--half"><%= text %></a>
 <% } %>

--- a/src/sass/object/component/_c-btn.scss
+++ b/src/sass/object/component/_c-btn.scss
@@ -34,3 +34,24 @@
     @include btn__hover--LtoR($gray, $white);
   }
 }
+
+//SP版は背景黒、文字白、PC版は背景白、文字黒の設定(高さは親要素に合わせる設定）
+.c-btn--half {
+  @extend .c-btn;
+  background-color: $gray;
+  color: $white;
+  border: rem(1) solid $white;
+  @include mq() {
+  background-color: $white;
+  color: $gray;
+  padding: 0;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  border: none;
+    //ホバーエフェクト
+    @include btn__hover--LtoR($gray, $white);
+  }
+}


### PR DESCRIPTION
トップページのニュース欄の『すべて見る』ボタンは、他と違いSP版とPC版で色が異なっているため、それ用の対応を追記しました。