### PR TITLE
news関係のfirst commit

### DIFF
--- a/src/ejs/parts/project/_p-news.ejs
+++ b/src/ejs/parts/project/_p-news.ejs
@@ -1,0 +1,12 @@
+<div class="l-news p-news">
+  <div class="p-news__wrapper">
+    <div class="p-news__header">
+      <time class="p-news__date">2020.07.20</time>
+      <div class="p-news__category">お知らせ</div>
+    </div>
+    <div class="p-news__titleblock">
+      <a href="#"
+        class="p-news__title">記事タイトルが入ります。記事タイトルが入ります。記事タイトルが入ります。記事タイトルが入ります。</a>
+    </div>
+  </div>
+</div>

--- a/src/ejs/parts/project/_p-top-news.ejs
+++ b/src/ejs/parts/project/_p-top-news.ejs
@@ -1,0 +1,16 @@
+<!-- トップページニュース欄 -->
+<article id="top-news" class="l-top-news p-top-news">
+  <div class="p-top-news__inner l-inner">
+    <div class="p-top-news__wrapper">
+
+      <div class="p-top-news__content">
+        <%- include('./_p-news') %>
+      </div>
+  
+      <div class="p-top-news__btnblock">
+        <%- include('../component/_c-btn',{text:'すべて見る', link:'#', backcolor:'half'}) %>
+      </div>
+
+    </div>
+  </div>
+</article>

--- a/src/sass/object/layout/_l-news.scss
+++ b/src/sass/object/layout/_l-news.scss
@@ -1,0 +1,3 @@
+.l-news {
+  max-width: rem(860);
+}

--- a/src/sass/object/layout/_l-top-news.scss
+++ b/src/sass/object/layout/_l-top-news.scss
@@ -1,0 +1,6 @@
+.l-top-news {
+  margin-top: rem(24);
+  @include mq() {
+    margin-top: rem(32);
+  }
+}

--- a/src/sass/object/project/_p-news.scss
+++ b/src/sass/object/project/_p-news.scss
@@ -1,0 +1,38 @@
+.p-news {}
+
+.p-news__wrapper {
+  @include mq() {
+    display: flex;
+    align-items: center;
+  }
+}
+
+.p-news__header {
+  display: flex;
+  align-items: center;
+  margin-right: rem(60);
+}
+
+.p-news__date {
+  margin-right: rem(48);
+  font-size: rem(16);
+}
+
+.p-news__category {
+  font-size: rem(14);
+  padding: rem(6) rem(22);
+  border: rem(1) solid $white;
+}
+
+.p-news__titleblock {
+  flex: 1;
+  margin-top: rem(16);
+  @include mq() {
+    margin-top: initial;
+  }
+}
+
+.p-news__title {
+  font-size: rem(16);
+  
+}

--- a/src/sass/object/project/_p-top-news.scss
+++ b/src/sass/object/project/_p-top-news.scss
@@ -1,0 +1,25 @@
+.p-top-news {}
+
+.p-top-news__inner {}
+
+.p-top-news__wrapper {
+  @include mq() {
+    display: flex;
+    align-items: center;
+  }
+}
+
+.p-top-news__content {
+  margin-right: rem(48);
+}
+
+.p-top-news__btnblock {
+  text-align: center;
+  margin-top: rem(28);
+  @include mq() {
+    max-width: rem(134);
+    width: 100%;
+    height: rem(30);
+    margin-top: initial;
+  }
+}


### PR DESCRIPTION
topページのニュース欄を作成しました。
ニュースの日付、カテゴリ、タイトル表示の部分は、下層ページの『お知らせ一覧ページ』でも使えるブロックのため、ファイルを分けて作成しました。