### PR TITLE
SP版表示崩れ修正

### DIFF
--- a/src/sass/object/project/_p-news.scss
+++ b/src/sass/object/project/_p-news.scss
@@ -10,7 +10,9 @@
 .p-news__header {
   display: flex;
   align-items: center;
-  margin-right: rem(60);
+  @include mq() {
+    margin-right: rem(60);
+  }
 }
 
 .p-news__date {

--- a/src/sass/object/project/_p-top-news.scss
+++ b/src/sass/object/project/_p-top-news.scss
@@ -10,7 +10,9 @@
 }
 
 .p-top-news__content {
-  margin-right: rem(48);
+  @include mq() {
+    margin-right: rem(48);
+  }
 }
 
 .p-top-news__btnblock {


### PR DESCRIPTION
■_p-top-news
SP版で以下の表示崩れを確認したため、修正しました。
・p-news__categoryが375px当たりから表示崩れを起こしている
　→p-news__headerにmargin-right: rem(60);が当たっている
・p-top-news__contentの右側に余白がある
　→p-top-news__contentにmargin-right: rem(48);が当たっている